### PR TITLE
Adding adequately formatted sponsor logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,10 @@ All material contained within are freely available under the GNU AFFERO GPL v3 l
 
 We would like to thank our main sponsor, the State Government of Penang for funding the work here to make programming accessible to all.
 
-[![The Penang State Government coat of arms](./resources/images/jata_pulau_pinang.svg|width=250px)](https://www.penang.gov.my/)
+<a href="https://www.penang.gov.my/">
+    <img 
+    src="./resources/images/jata_pulau_pinang.svg" 
+    alt="The Penang State Government coat of arms"
+    width="150"
+    >
+</a>

--- a/README.md
+++ b/README.md
@@ -9,3 +9,5 @@ All material contained within are freely available under the GNU AFFERO GPL v3 l
 # Sponsors
 
 We would like to thank our main sponsor, the State Government of Penang for funding the work here to make programming accessible to all.
+
+[![The Penang State Government coat of arms](./resources/images/jata_pulau_pinang.svg|width=250px)](https://www.penang.gov.my/)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,6 @@ We would like to thank our main sponsor, the State Government of Penang for fund
     <img 
     src="./resources/images/jata_pulau_pinang.svg" 
     alt="The Penang State Government coat of arms"
-    width="150"
+    width="100"
     >
 </a>

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ All material contained within are freely available under the GNU AFFERO GPL v3 l
 
 # Sponsors
 
-We would like to thank our main sponsor, the State Government of Penang for funding the work here to make programming accessible to all.
+We would like to thank our main sponsor, the Penang State Government for funding the work in this project to make learning to code more accessible to everyone.
 
 <a href="https://www.penang.gov.my/">
     <img 


### PR DESCRIPTION
After testing, I conclude that markdown support for image resizing is still a work-in-progress and have settled on using 100px width as the current standard for sponsorship logo placement in our repository's README file.

I have also changed up the sponsorship blurb to flow better.